### PR TITLE
feat: centralize TA-Lib import with wrapper

### DIFF
--- a/quant_intraday/core/strategies.py
+++ b/quant_intraday/core/strategies.py
@@ -1,43 +1,7 @@
 import numpy as np
 import pandas as pd
 
-# Attempt to import the C extension for technical indicators.  If unavailable
-# fall back to our pure‑Python implementations in utils.talib_fallback.  This
-# wrapper makes it transparent for the rest of the strategy code to call
-# indicator functions via ``ta.<func>``.
-try:
-    import talib as ta  # type: ignore
-except ImportError:
-    from ..utils.talib_fallback import (
-        EMA as _EMA,
-        ATR as _ATR,
-        RSI as _RSI,
-        BBANDS as _BBANDS,
-        OBV as _OBV,
-    )  # noqa: F401
-
-    class _Fallback:
-        @staticmethod
-        def EMA(*args, **kwargs):
-            return _EMA(*args, **kwargs)
-
-        @staticmethod
-        def ATR(*args, **kwargs):
-            return _ATR(*args, **kwargs)
-
-        @staticmethod
-        def RSI(*args, **kwargs):
-            return _RSI(*args, **kwargs)
-
-        @staticmethod
-        def BBANDS(*args, **kwargs):
-            return _BBANDS(*args, **kwargs)
-
-        @staticmethod
-        def OBV(*args, **kwargs):
-            return _OBV(*args, **kwargs)
-
-    ta = _Fallback()
+from ..utils.talib_wrapper import ta
 from .common import Signal
 
 class BaseStrategy:

--- a/quant_intraday/utils/talib_wrapper.py
+++ b/quant_intraday/utils/talib_wrapper.py
@@ -1,0 +1,17 @@
+"""Unified TA-Lib import wrapper.
+
+This module exposes a single object ``ta`` that provides technical
+indicator functions.  It first attempts to import the official
+``talib`` package.  If that fails (for example when the C extension is
+not installed), it falls back to the minimal pure-Python implementations
+in :mod:`quant_intraday.utils.talib_fallback`.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - import side effects
+    import talib as ta  # type: ignore
+except Exception:  # pragma: no cover - no talib available
+    from . import talib_fallback as ta  # type: ignore
+
+__all__ = ["ta"]

--- a/tests/test_talib_wrapper.py
+++ b/tests/test_talib_wrapper.py
@@ -1,0 +1,31 @@
+import importlib
+import sys
+import builtins
+import numpy as np
+
+from quant_intraday.utils import talib_fallback
+
+
+def test_talib_wrapper_fallback(monkeypatch):
+    """Wrapper should fall back to pure-Python implementations when TALib is missing."""
+    monkeypatch.delitem(sys.modules, "talib", raising=False)
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "talib":
+            raise ImportError
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    module_name = "quant_intraday.utils.talib_wrapper"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    wrapper = importlib.import_module(module_name)
+
+    c = np.array([1.0, 2.0, 3.0])
+    h = l = c
+    res = wrapper.ta.ATR(h, l, c, 1)
+    exp = talib_fallback.ATR(h, l, c, 1)
+    assert np.allclose(res, exp)


### PR DESCRIPTION
## Summary
- add `talib_wrapper` module exposing `ta` with automatic fallback to `talib_fallback`
- refactor strategy and engine modules to use unified `ta` wrapper
- cover missing TA-Lib scenario with new tests

## Testing
- `PYTHONPATH=. pytest tests/test_talib_wrapper.py -q`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'typer')*


------
https://chatgpt.com/codex/tasks/task_e_689c5b169bdc83208180dea4e38c1436